### PR TITLE
fix: robust TPP checkpoint loading

### DIFF
--- a/src/tpp_runtime.py
+++ b/src/tpp_runtime.py
@@ -32,121 +32,85 @@ class TPPRuntime:
             raise FileNotFoundError(f"Checkpoint not found: {ckpt}")
 
         print(f"Loading TPP checkpoint: {ckpt}")
-        
-        # Method 1: Try official Trajectron++ loading
+
+        # Load checkpoint once for format inspection
+        checkpoint = torch.load(ckpt, map_location="cpu" if force_cpu_load else self.device)
+
+        # Create registrar and model for manual loading attempts
+        registrar = ModelRegistrar(model_dir, self.device)
+        model = Trajectron(registrar, hyperparams, device=self.device, log_writer=None)
+
+        # 1) Check for state_dict format used by official Trajectron++ saves
+        if isinstance(checkpoint, dict) and "model_state_dict" in checkpoint:
+            try:
+                model.load_state_dict(checkpoint["model_state_dict"], strict=False)
+                self.model = model
+                self.model.eval()
+                self.loaded = True
+                print("✓ TPP loaded via model_state_dict")
+                if eager:
+                    for p in self.model.parameters():
+                        p.data = p.data.to(self.device, copy=True)
+                return
+            except Exception as e:
+                print(f"  Failed to load model_state_dict: {e}")
+
+        # 2) Direct ModuleDict checkpoint
+        if isinstance(checkpoint, nn.ModuleDict):
+            registrar.model_dict = checkpoint.to(self.device)
+            self.model = model
+            self.model.eval()
+            self.loaded = True
+            print("✓ TPP loaded via ModuleDict assignment")
+            if eager:
+                for p in self.model.parameters():
+                    p.data = p.data.to(self.device, copy=True)
+            return
+
+        # 3) Plain dictionary checkpoint
+        if isinstance(checkpoint, dict):
+            model_dict = checkpoint.get("model_dict", checkpoint)
+
+            # 3a) Dict of actual modules -> convert to ModuleDict
+            if all(isinstance(v, nn.Module) for v in model_dict.values()):
+                registrar.model_dict = nn.ModuleDict(model_dict).to(self.device)
+                self.model = model
+                self.model.eval()
+                self.loaded = True
+                print("✓ TPP loaded via dict->ModuleDict conversion")
+                if eager:
+                    for p in self.model.parameters():
+                        p.data = p.data.to(self.device, copy=True)
+                return
+
+            # 3b) Dict of state_dicts -> load each into existing modules
+            if all(isinstance(v, dict) for v in model_dict.values()):
+                for name, state in model_dict.items():
+                    if name in registrar.model_dict:
+                        registrar.model_dict[name].load_state_dict(state, strict=False)
+                self.model = model
+                self.model.eval()
+                self.loaded = True
+                print("✓ TPP loaded via per-module state_dicts")
+                if eager:
+                    for p in self.model.parameters():
+                        p.data = p.data.to(self.device, copy=True)
+                return
+
+        # 4) Fallback to official loader as last resort
         try:
             registrar = ModelRegistrar(model_dir, self.device)
-            registrar.load_models(iteration)  # This calls the official method
+            registrar.load_models(iteration)
             self.model = Trajectron(registrar, hyperparams, device=self.device, log_writer=None)
             self.model.eval()
             self.loaded = True
-            print(f"✓ TPP loaded via official method")
+            print("✓ TPP loaded via official method")
             if eager:
                 for p in self.model.parameters():
                     p.data = p.data.to(self.device, copy=True)
             return
         except Exception as e:
             print(f"Official TPP loading failed: {e}")
-
-        # Method 2: Manual checkpoint loading with proper dict->ModuleDict conversion
-        try:
-            print("Attempting manual checkpoint loading...")
-            checkpoint = torch.load(ckpt, map_location="cpu" if force_cpu_load else self.device)
-            
-            # Create fresh registrar and model
-            registrar = ModelRegistrar(model_dir, self.device)
-            model = Trajectron(registrar, hyperparams, device=self.device, log_writer=None)
-            
-            # Method 2a: If checkpoint is a ModuleDict directly
-            if isinstance(checkpoint, nn.ModuleDict):
-                print("Checkpoint is ModuleDict format")
-                registrar.model_dict = checkpoint.to(self.device)
-                self.model = model
-                self.model.eval()
-                self.loaded = True
-                print("✓ TPP loaded via ModuleDict assignment")
-                return
-                
-            # Method 2b: If checkpoint is a dict of state_dicts
-            elif isinstance(checkpoint, dict):
-                print("Checkpoint is dict format, converting...")
-                
-                # Check if it's a dict of modules vs dict of state_dicts
-                first_key = next(iter(checkpoint.keys()))
-                first_value = checkpoint[first_key]
-                
-                if isinstance(first_value, nn.Module):
-                    # Dict of modules -> convert to ModuleDict
-                    model_dict = nn.ModuleDict(checkpoint)
-                    registrar.model_dict = model_dict.to(self.device)
-                    self.model = model
-                    self.model.eval()
-                    self.loaded = True
-                    print("✓ TPP loaded via dict-of-modules conversion")
-                    return
-                    
-                elif isinstance(first_value, dict):
-                    # Dict of state_dicts -> need to create modules first
-                    print("Checkpoint contains state_dicts, attempting reconstruction...")
-                    
-                    # Initialize the model first to create the architecture
-                    model.eval()  # This should create the basic structure
-                    
-                    # Try to load state_dicts into existing modules
-                    if hasattr(registrar, 'model_dict') and isinstance(registrar.model_dict, nn.ModuleDict):
-                        loaded_any = False
-                        for name, state_dict in checkpoint.items():
-                            if name in registrar.model_dict:
-                                try:
-                                    registrar.model_dict[name].load_state_dict(state_dict, strict=False)
-                                    loaded_any = True
-                                    print(f"  Loaded state_dict for {name}")
-                                except Exception as e:
-                                    print(f"  Failed to load {name}: {e}")
-                        
-                        if loaded_any:
-                            self.model = model
-                            self.model.eval()
-                            self.loaded = True
-                            print("✓ TPP loaded via state_dict loading")
-                            return
-                    
-                    # If that failed, try creating a new ModuleDict
-                    # This is a last resort - create empty modules and load weights
-                    model_dict = nn.ModuleDict()
-                    for name, state_dict in checkpoint.items():
-                        try:
-                            # Try to infer module type from state_dict structure
-                            # This is heuristic and may not work for all cases
-                            if 'weight' in state_dict and 'bias' in state_dict:
-                                # Looks like a linear layer
-                                weight_shape = state_dict['weight'].shape
-                                if len(weight_shape) == 2:
-                                    module = nn.Linear(weight_shape[1], weight_shape[0])
-                                else:
-                                    continue  # Skip unknown architectures
-                            else:
-                                continue  # Skip modules we can't reconstruct
-                            
-                            module.load_state_dict(state_dict, strict=False)
-                            model_dict[name] = module
-                            print(f"  Reconstructed module {name}")
-                        except Exception as e:
-                            print(f"  Failed to reconstruct {name}: {e}")
-                            continue
-                    
-                    if len(model_dict) > 0:
-                        registrar.model_dict = model_dict.to(self.device)
-                        self.model = model
-                        self.model.eval()
-                        self.loaded = True
-                        print(f"✓ TPP loaded via module reconstruction ({len(model_dict)} modules)")
-                        return
-            
-            print("All manual loading methods failed")
-            
-        except Exception as e:
-            print(f"Manual loading failed: {e}")
 
         # Method 3: Create empty model as last resort
         try:


### PR DESCRIPTION
## Summary
- load checkpoint once and handle `model_state_dict`, `ModuleDict`, plain module dicts, and dicts of per-module state dicts
- fall back to official loader only if manual paths fail

## Testing
- `python -m py_compile src/tpp_runtime.py`


------
https://chatgpt.com/codex/tasks/task_e_68ade31b8040832589b05733a62ce7d2